### PR TITLE
feat(helm): add log level configuration option

### DIFF
--- a/charts/cron-operator/README.md
+++ b/charts/cron-operator/README.md
@@ -17,6 +17,7 @@ A Kubernetes operator that enables cron-based scheduling for machine learning tr
 | image.pullSecrets | list | `[]` | Image pull secrets. |
 | replicas | int | `1` | Number of replicas. |
 | logEncoder | string | `"console"` | Configure the encoder of logging, can be one of `console` or `json`. |
+| logLevel | string | `"info"` | Configure the verbosity of logging, can be one of `debug`, `info`, `error`. |
 | leaderElection.enable | bool | `true` | Whether to enable leader election. |
 | maxConcurrentReconciles | int | `10` | Maximum number of concurrent reconciles. |
 | qps | int | `30` | Maximum QPS to the Kubernetes API server from this client. |

--- a/charts/cron-operator/templates/deployment.yaml
+++ b/charts/cron-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         {{- with .Values.logEncoder}}
         - --zap-encoder={{ . }}
         {{- end }}
+        {{- with .Values.logLevel }}
+        - --zap-level={{ . }}
+        {{- end }}
         - --leader-elect={{ .Values.leaderElection.enable }}
         {{- with .Values.maxConcurrentReconciles }}
         - --max-concurrent-reconciles={{ . }}

--- a/charts/cron-operator/tests/deployment_test.yaml
+++ b/charts/cron-operator/tests/deployment_test.yaml
@@ -60,6 +60,14 @@ tests:
       path: spec.template.spec.containers[?(@.name=='cron-operator')].args
       content: --zap-encoder=json
 
+- it: Should use specified log level
+  set:
+    logLevel: debug
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[?(@.name=='cron-operator')].args
+      content: --zap-level=debug
+
 - it: Should enable leader election if `leaderElection.enable` is set to true
   set:
     leaderElection:

--- a/charts/cron-operator/values.yaml
+++ b/charts/cron-operator/values.yaml
@@ -42,6 +42,9 @@ replicas: 1
 # -- Configure the encoder of logging, can be one of `console` or `json`.
 logEncoder: console
 
+# -- Configure the verbosity of logging, can be one of `debug`, `info`, `error`.
+logLevel: info
+
 leaderElection:
   # -- Whether to enable leader election.
   enable: true


### PR DESCRIPTION
- Add `logLevel` value to `values.yaml` with default `info`.
- Pass `--zap-level` argument to container args in `deployment.yaml`.
- Add test case to verify log level argument is set correctly.